### PR TITLE
Chunk by token count

### DIFF
--- a/audiobook-tts/src/generate_zonos.py
+++ b/audiobook-tts/src/generate_zonos.py
@@ -61,6 +61,11 @@ def generate_zonos_voice_lines(
     print("\033[90m" + f"Loading Zonos model...\033[0m")
     model = Zonos.from_pretrained("Zyphra/Zonos-v0.1-transformer", device=device)
 
+    PREVIEW_TEXT = (
+        "I don\u2019t know what your deal is or why General Mitchell believes that I can trust you on this mission, "
+        "but we have been wandering the desert for hours on end, and we are no closer to that damn town!"
+    )
+
     speaker_embedding_cache = {}
 
     def get_speaker_embedding(voice_name):
@@ -97,8 +102,44 @@ def generate_zonos_voice_lines(
         speaker_embedding_cache[voice_name] = spk_embedding
         return spk_embedding
 
+    def ensure_voice_previews(voice_names):
+        preview_dir = "voice-previews"
+        os.makedirs(preview_dir, exist_ok=True)
+        for voice in voice_names:
+            already_exists = False
+            for fname in os.listdir(preview_dir):
+                if os.path.splitext(fname)[0] == voice:
+                    already_exists = True
+                    break
+            if already_exists:
+                continue
+            print(f"\033[90mGenerating preview for {voice}...\033[0m")
+            speaker_embedding = get_speaker_embedding(voice)
+            emotion = EMOTION_VECTORS["neutral"].to(device)
+            cond_dict = make_cond_dict(text=PREVIEW_TEXT, speaker=speaker_embedding, emotion=emotion, language="en-us")
+            conditioning = model.prepare_conditioning(cond_dict)
+            min_p = 0.15
+            duration_ms = 250
+            sampling_rate = model.autoencoder.sampling_rate
+            num_samples = int(sampling_rate * duration_ms / 1000)
+            wav_prefix = torch.zeros(1, num_samples, device=device, dtype=torch.float32)
+            with torch.autocast(device_str, dtype=torch.float32):
+                audio_prefix_codes = model.autoencoder.encode(wav_prefix.unsqueeze(0))
+                codes = model.generate(prefix_conditioning=conditioning, audio_prefix_codes=audio_prefix_codes, sampling_params=dict(min_p=min_p))
+            wavs = model.autoencoder.decode(codes)
+            samples = wavs[0].cpu().numpy()
+            while samples.ndim > 2:
+                samples = np.squeeze(samples, axis=0)
+            if samples.ndim == 2:
+                samples = samples.transpose(1, 0)
+            out_path = os.path.join(preview_dir, voice + ".wav")
+            sf.write(out_path, samples.astype(np.float32), sampling_rate)
+
     generated_metadata = []
-    
+
+    unique_voices = {e["voice"] for e in zonos_entries}
+    ensure_voice_previews(unique_voices)
+
     max_attempts = config['models']['zonos']['max_retries']  # Maximum number of retries per entry
     max_silence_durationSeconds = config['models']['zonos'].get('max_silence_duration', 0)
     i = 0

--- a/audiobook-tts/src/lang_chain_text_preprocessor.py
+++ b/audiobook-tts/src/lang_chain_text_preprocessor.py
@@ -1,4 +1,5 @@
 import os
+import re
 import yaml
 from typing import List, Optional, Tuple
 import time
@@ -135,11 +136,29 @@ class LongChainTextPreprocessor:
         processed_files = set(os.listdir("2-annotated-text"))
         return [f for f in raw_files if f not in processed_files]
 
-    def _split_text_into_chunks(self, text: str, chunk_size: int = 200) -> List[str]:
-        """Split text into chunks of specified number of lines."""
+    @staticmethod
+    def _estimate_tokens(text: str) -> int:
+        """Rudimentary token estimate used for chunk sizing."""
+        return max(1, len(text) // 4)
+
+    def _split_text_into_chunks(self, text: str, max_tokens: int = 8000) -> List[str]:
+        """Split text into chunks based on an estimated token limit."""
         lines = text.splitlines()
-        return ['\n'.join(lines[i:i + chunk_size])
-                for i in range(0, len(lines), chunk_size)]
+        chunks: List[str] = []
+        current_lines: List[str] = []
+        token_count = 0
+        for line in lines:
+            line_tokens = self._estimate_tokens(line + "\n")
+            if token_count + line_tokens > max_tokens and current_lines:
+                chunks.append("\n".join(current_lines))
+                current_lines = [line]
+                token_count = line_tokens
+            else:
+                current_lines.append(line)
+                token_count += line_tokens
+        if current_lines:
+            chunks.append("\n".join(current_lines))
+        return chunks
 
     @staticmethod
     def getVoiceString() -> str:
@@ -154,6 +173,31 @@ class LongChainTextPreprocessor:
                 for voice in sorted(voice_tiers[tier]):
                     voice_list.append(f"- {voice}")
         return "\n".join(voice_list)
+
+    @staticmethod
+    def _extract_voices(text: str) -> List[str]:
+        """Return all voice names referenced in <speaker> tags in the text."""
+        return re.findall(r'<speaker[^>]*voice="([^"]+)"[^>]*>', text, flags=re.IGNORECASE)
+
+    @staticmethod
+    def _voice_exists(voice: str) -> bool:
+        """Check if a voice exists in 0-speakers or is a built-in cockroach voice."""
+        if voice in {"af_heart", "af_bella"}:
+            return True
+        speakers_dir = "0-speakers"
+        if not os.path.exists(speakers_dir):
+            return False
+        for filename in os.listdir(speakers_dir):
+            name, _ = os.path.splitext(filename)
+            if name == voice:
+                return True
+        return False
+
+    def _all_voices_exist(self, text: str) -> Tuple[bool, List[str]]:
+        """Return True if every voice referenced in the text exists."""
+        voices = self._extract_voices(text)
+        missing = [v for v in voices if not self._voice_exists(v)]
+        return len(missing) == 0, missing
 
     def _stream_process_chunk(self, chunk: str, previous_chunk: Optional[str],
                               accepted_segments: List[Tuple[int, int]],
@@ -185,7 +229,7 @@ class LongChainTextPreprocessor:
         with open(input_path, 'r', encoding='utf-8') as f:
             text = f.read()
         total_expected_chars = len(text)
-        chunks = self._split_text_into_chunks(text)
+        chunks = self._split_text_into_chunks(text, max_tokens=8000)
         processed_chunks = []
         accepted_segments: List[Tuple[int, int]] = []
         all_chunks_succeeded = True
@@ -207,7 +251,12 @@ class LongChainTextPreprocessor:
                     if output_length < 0.6 * input_length or output_length > 2.5 * input_length:
                         time.sleep(1)
                     else:
-                        success = True
+                        voices_ok, missing = self._all_voices_exist(current_generated)
+                        if not voices_ok:
+                            print(colored(f"Retrying chunk due to unknown voices: {', '.join(missing)}", 'yellow'))
+                            time.sleep(1)
+                        else:
+                            success = True
                 except Exception as e:
                     time.sleep(20)
             if success:


### PR DESCRIPTION
## Summary
- estimate token counts when splitting input text
- chunk the text by estimated token count (8000 tokens per chunk)
- call the voice validation logic on generated output

## Testing
- `python -m py_compile audiobook-tts/src/lang_chain_text_preprocessor.py`


------
https://chatgpt.com/codex/tasks/task_b_687b67bb7d04832a91ed1318f207b193