### PR TITLE
Add checks for existing audio files and cleanup

### DIFF
--- a/audiobook-tts/run.sh
+++ b/audiobook-tts/run.sh
@@ -3,19 +3,19 @@ set -e
 
 python src/lang_chain_text_preprocessor.py
 
-# Loop through all text files in the 2-annotated-text directory
-for file in 2-annotated-text/*.txt; do
+# Loop through all text files in the 2-annotated-text directory in
+# deterministic order
+for file in $(ls 2-annotated-text/*.txt | sort); do
   # Get the filename without the path
   filename=$(basename "$file")
   # Get the filename without the extension
   filename_no_ext="${filename%.*}"
 
-  # Check if the 3-output file already exists
-# Check if any file with the same base name exists in the 3-output directory
-if ls "3-output/${filename_no_ext}."* 1> /dev/null 2>&1; then
-  echo -e "\e[90mOutput file output/${filename_no_ext} already exists. Skipping\e[0m"
-  continue
-fi
+  # Check if any file with the same base name exists in the 3-output directory
+  if ls "3-output/${filename_no_ext}."* 1> /dev/null 2>&1; then
+    echo -e "\e[90mOutput for ${filename_no_ext} already exists. Skipping\e[0m"
+    continue
+  fi
 
 
   # Split voice lines
@@ -26,7 +26,7 @@ fi
   python src/generate_zonos.py
   deactivate
 
-# Generate Kokoro voice lines
+  # Generate Kokoro voice lines
   source venv_kokoro/bin/activate
   python src/generate_kokoro.py
   deactivate

--- a/audiobook-tts/src/generate_kokoro.py
+++ b/audiobook-tts/src/generate_kokoro.py
@@ -83,6 +83,19 @@ def generate_kokoro_voice_lines(modelPath, voicesPath, temp_folder="temp", voice
         elif resolved_voice is None:
             print(f"\033[33mVoice {voice} not found; using provided name anyway.\033[0m")
         text_chunk = entry["text"]
+        out_filename = os.path.join(temp_folder, f"chunk_{idx:04d}.wav")
+
+        if os.path.exists(out_filename):
+            try:
+                info = sf.info(out_filename)
+                if info.frames > 0:
+                    print(f"\033[90mChunk {idx} already exists. Skipping generation.\033[0m")
+                    entry["filename"] = out_filename
+                    generated_metadata.append(entry)
+                    continue
+            except Exception:
+                print(f"\033[33mExisting file {out_filename} is invalid. Regenerating.\033[0m")
+
         print_generation_status("Kokoro", idx + 1, len(kokoro_entries), len(text_chunk),
                                 kokoro_min_chars, kokoro_max_chars, text_chunk)
         current_sample_rate = SAMPLE_RATE
@@ -91,7 +104,7 @@ def generate_kokoro_voice_lines(modelPath, voicesPath, temp_folder="temp", voice
             samples = np.zeros(int(silence_durationSec * current_sample_rate), dtype=np.float32)
         else:
             samples, _ = kokoro.create(text_chunk, voice=voice, speed=voiceSpeed01)
-        out_filename = os.path.join(temp_folder, f"chunk_{idx:04d}.wav")
+
         sf.write(out_filename, samples, current_sample_rate)
         entry["filename"] = out_filename
         generated_metadata.append(entry)

--- a/audiobook-tts/src/generate_zonos.py
+++ b/audiobook-tts/src/generate_zonos.py
@@ -150,6 +150,18 @@ def generate_zonos_voice_lines(
         text_chunk = entry["text"]
         emotion_tag = entry.get("emotion", "")
 
+        out_filename = os.path.join(temp_folder, f"chunk_{idx:04d}.wav")
+        if os.path.exists(out_filename):
+            try:
+                info = sf.info(out_filename)
+                if info.frames > 0:
+                    print(f"\033[90mChunk {idx} already exists. Skipping generation.\033[0m")
+                    entry["filename"] = out_filename
+                    generated_metadata.append(entry)
+                    continue
+            except Exception:
+                print(f"\033[33mExisting file {out_filename} is invalid. Regenerating.\033[0m")
+
         print_generation_status("Zonos", i, len(zonos_entries), len(text_chunk), zonos_min_chars, zonos_max_chars, text_chunk)
 
         # Prepare conditioning parameters (these remain the same across retries)
@@ -193,7 +205,6 @@ def generate_zonos_voice_lines(
             if samples.ndim == 2:
                 samples = samples.transpose(1, 0)
 
-            out_filename = os.path.join(temp_folder, f"chunk_{idx:04d}.wav")
             sf.write(out_filename, samples, sampling_rate)
 
             data, samplerate = sf.read(out_filename)

--- a/audiobook-tts/src/merge_voice_lines.py
+++ b/audiobook-tts/src/merge_voice_lines.py
@@ -178,12 +178,22 @@ def merge_voice_lines(temp_folder="temp", output_folder="3-output"):
             "-y",  # Overwrite output file if it exists.
             final_output
         ]
+
         result = subprocess.run(ffmpeg_command, capture_output=True, text=True)
         if result.returncode == 0:
             os.remove(intermediate_wav)
             print_header(f"Success! Final output at {final_output}")
         else:
             print(f"\033[31mFFmpeg conversion failed: {result.stderr}\033[0m")
+
+    # Clean up temporary files once all sources have been processed
+    for fname in os.listdir(temp_folder):
+        if fname.startswith("chunk_") and fname.endswith(".wav"):
+            os.remove(os.path.join(temp_folder, fname))
+    for meta in ["metadata_split.json", "metadata_generated_zonos.json", "metadata_generated_kokoro.json"]:
+        path = os.path.join(temp_folder, meta)
+        if os.path.exists(path):
+            os.remove(path)
 
 if __name__ == "__main__":
     merge_voice_lines()


### PR DESCRIPTION
## Summary
- skip generation for existing, valid chunks
- cleanup temp files after merging
- ensure text files are processed in a deterministic order

## Testing
- `python -m py_compile audiobook-tts/src/*.py`

------
https://chatgpt.com/codex/tasks/task_b_687ba6315b80832a8a688a86d6a167b0