### PR TITLE
Enable multithreaded chunked preprocessing

### DIFF
--- a/0-prompts/determine-and-summarize-speakers-prompt.md
+++ b/0-prompts/determine-and-summarize-speakers-prompt.md
@@ -1,0 +1,19 @@
+You will receive a raw story that will be turned into an audiobook.
+Identify every speaker or entity that has spoken text in the story. Include narrator voices, named characters and any other entity that should speak with a distinct voice.
+For each of them provide the following information strictly in this format:
+
+# Speaker {number}
+Name: <short name or identifier>
+Description: <short description of the character>
+Personality & behaviour: <key traits>
+Voice type: <choose from the list below>
+
+Use each speaker only once and do not omit anyone. Reply only with the list of speakers.
+
+Available voices:
+{voices}
+
+Story text:
+```
+{text}
+```

--- a/0-prompts/edit-raw-story-prompt.md
+++ b/0-prompts/edit-raw-story-prompt.md
@@ -26,6 +26,9 @@ If the story has multiple unrelated sections, you may reuse voices you have used
 Available Voices:
 {voices}
 
+Character summary:
+{character_summary}
+
 Only choose from these. There are no other voices available
 
 For timestamps, convert them into natural language, showing elapsed time only if relevant.  

--- a/audiobook-tts/src/lang_chain_text_preprocessor.py
+++ b/audiobook-tts/src/lang_chain_text_preprocessor.py
@@ -13,6 +13,7 @@ from langchain.callbacks.base import BaseCallbackHandler
 from langchain.callbacks.manager import CallbackManager
 
 from generate_helper import listAvailableVoices, resolve_voice_name
+from text_utils import TextUtils
 
 def colored(text: str, color: str) -> str:
     color_codes = {
@@ -123,8 +124,10 @@ class LongChainTextPreprocessor:
     def __init__(self, config_path: str = "configuration.yaml"):
         self.config = self._load_config(config_path)
         self.llm = self._setup_llm()
-        # Load only the editing prompt (character analysis prompt removed)
+        # Load prompts
         self.edit_prompt = self._load_prompt("prompts/edit-raw-story-prompt.md")
+        self.speaker_prompt = self._load_prompt(
+            "prompts/determine-and-summarize-speakers-prompt.md")
         
     def _load_config(self, config_path: str) -> dict:
         """Load configuration from YAML file."""
@@ -181,24 +184,9 @@ class LongChainTextPreprocessor:
         """Rudimentary token estimate used for chunk sizing."""
         return max(1, len(text) // 4)
 
-    def _split_text_into_chunks(self, text: str, max_tokens: int = 8000) -> List[str]:
-        """Split text into chunks based on an estimated token limit."""
-        lines = text.splitlines()
-        chunks: List[str] = []
-        current_lines: List[str] = []
-        token_count = 0
-        for line in lines:
-            line_tokens = self._estimate_tokens(line + "\n")
-            if token_count + line_tokens > max_tokens and current_lines:
-                chunks.append("\n".join(current_lines))
-                current_lines = [line]
-                token_count = line_tokens
-            else:
-                current_lines.append(line)
-                token_count += line_tokens
-        if current_lines:
-            chunks.append("\n".join(current_lines))
-        return chunks
+    def _split_text_into_chunks(self, text: str, max_chars: int = 10000) -> List[str]:
+        """Split text into chunks without cutting sentences."""
+        return TextUtils.chunk_text(text, max_chars=max_chars)
 
     @staticmethod
     def getVoiceString() -> str:
@@ -230,9 +218,17 @@ class LongChainTextPreprocessor:
         missing = [v for v in voices if not self._voice_exists(v)]
         return len(missing) == 0, missing
 
-    def _stream_process_chunk(self, chunk: str, previous_chunk: Optional[str],
-                              accepted_segments: List[Tuple[int, int]],
-                              total_expected_chars: int, chunk_index: int) -> str:
+    def _determine_speakers(self, text: str) -> str:
+        """Use the language model to summarize all speakers in the text."""
+        prompt = ChatPromptTemplate.from_template(self.speaker_prompt)
+        messages = prompt.format_messages(
+            voices=self.getVoiceString(),
+            text=text,
+        )
+        result = self.llm.invoke(messages)
+        return result.content.strip() if hasattr(result, "content") else str(result)
+
+    def _stream_process_chunk(self, chunk: str, chunk_index: int, summary: str) -> str:
         """
         Process a single chunk with streaming.
         A MyProgressBar instance is created to reflect overall progress,
@@ -241,18 +237,42 @@ class LongChainTextPreprocessor:
         prompt = ChatPromptTemplate.from_template(self.edit_prompt)
         messages = prompt.format_messages(
             voices=self.getVoiceString(),
-            previous_chunk=previous_chunk if previous_chunk else "None",
+            character_summary=summary,
             text=chunk
         )
-        progress_bar = MyProgressBar(accepted_segments, total_expected_chars, chunk_index, self.current_file_identifier)
-        update_progress(self.current_file_identifier, progress_bar.render_string())
+        identifier = f"{self.current_file_identifier}-{chunk_index}"
+        progress_bar = MyProgressBar([], len(chunk), chunk_index, identifier)
+        update_progress(identifier, progress_bar.render_string())
         callback = ProgressCallback(progress_bar)
         # Temporarily add the callback to the LLM's callback manager.
         self.llm.callback_manager.add_handler(callback)
         for _ in self.llm.invoke(messages, stream=True):
             pass
         self.llm.callback_manager.remove_handler(callback)
+        with progress_lock:
+            progress_states.pop(identifier, None)
         return callback.collected_text
+
+    def _process_chunk_with_retry(self, chunk: str, chunk_index: int, summary: str, max_attempts: int = 3) -> Tuple[int, Optional[str]]:
+        attempt = 0
+        while attempt < max_attempts:
+            attempt += 1
+            try:
+                result = self._stream_process_chunk(chunk, chunk_index, summary)
+                input_length = len(chunk)
+                output_length = len(result)
+                if output_length < 0.6 * input_length or output_length > 2.5 * input_length:
+                    time.sleep(1)
+                    continue
+                voices_ok, missing = self._all_voices_exist(result)
+                if not voices_ok:
+                    safe_print(colored(f"Retrying chunk due to unknown voices: {', '.join(missing)}", 'yellow'))
+                    time.sleep(1)
+                    continue
+                return chunk_index, result
+            except Exception:
+                time.sleep(20)
+        return chunk_index, None
 
     def process_file(self, filename: str):
         """Process a single file through the pipeline only if all chunks succeed."""
@@ -261,82 +281,46 @@ class LongChainTextPreprocessor:
         input_path = os.path.join("1-raw-text", filename)
         with open(input_path, 'r', encoding='utf-8') as f:
             text = f.read()
-        total_expected_chars = len(text)
-        chunks = self._split_text_into_chunks(text, max_tokens=8000)
-        processed_chunks = []
-        accepted_segments: List[Tuple[int, int]] = []
-        all_chunks_succeeded = True
-        update_progress(self.current_file_identifier, MyProgressBar([], total_expected_chars, 0, self.current_file_identifier).render_string())
-        for i, chunk in enumerate(chunks, 1):
-            previous_chunks_text = '\n'.join(processed_chunks)
-            max_attempts = 3
-            attempt = 0
-            success = False
-            current_generated = ""
-            while attempt < max_attempts and not success:
-                attempt += 1
-                try:
-                    current_generated = self._stream_process_chunk(chunk, previous_chunks_text,
-                                                                accepted_segments, total_expected_chars, chunk_index=i-1)
-                    input_length = len(chunk)
-                    output_length = len(current_generated)
-                    if output_length < 0.6 * input_length or output_length > 2.5 * input_length:
-                        time.sleep(1)
-                    else:
-                        voices_ok, missing = self._all_voices_exist(current_generated)
-                        if not voices_ok:
-                            safe_print(colored(f"Retrying chunk due to unknown voices: {', '.join(missing)}", 'yellow'))
-                            time.sleep(1)
-                        else:
-                            success = True
-                except Exception as e:
-                    time.sleep(20)
-            if success:
-                accepted_segments.append((i-1, len(current_generated)))
-                processed_chunks.append(current_generated)
-            else:
-                safe_print(colored("Failed to generate. Language model did not produce enough or produced too many characters after 3 tries. Process for this file will be aborted.", 'red'))
-                all_chunks_succeeded = False
-                break
-            all_chunks_succeeded = all_chunks_succeeded and success
-            time.sleep(1)
-        if all_chunks_succeeded:
-            output_path = os.path.join("2-annotated-text", filename)
-            with open(output_path, 'w', encoding='utf-8') as f:
-                f.write('\n'.join(processed_chunks))
-            safe_print(colored(f"\n✓ Completed processing: 2-annotated-text/{filename}\n", 'green'))
-        else:
-            safe_print(colored("File processing incomplete due to failed chunks. Processed file not written.", 'red'))
-        with progress_lock:
-            progress_states.pop(self.current_file_identifier, None)
+        # Determine speakers first
+        speaker_summary = self._determine_speakers(text)
+        safe_print(colored("Speakers determined", 'green'))
+
+        chunks = self._split_text_into_chunks(text)
+        results: List[Optional[str]] = [None] * len(chunks)
+        stop_event = threading.Event()
+        printer = threading.Thread(target=progress_printer, args=(stop_event,), daemon=True)
+        printer.start()
+        with ThreadPoolExecutor(max_workers=min(10, len(chunks))) as executor:
+            futures = {executor.submit(self._process_chunk_with_retry, chunk, idx, speaker_summary): idx for idx, chunk in enumerate(chunks)}
+            for future in as_completed(futures):
+                idx, res = future.result()
+                if res is None:
+                    stop_event.set()
+                    printer.join()
+                    safe_print(colored("Failed to generate. Aborting file.", 'red'))
+                    return
+                results[idx] = res
+        stop_event.set()
+        printer.join()
+
+        output_path = os.path.join("2-annotated-text", filename)
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write('\n'.join(results))
+        safe_print(colored(f"\n✓ Completed processing: 2-annotated-text/{filename}\n", 'green'))
 
     def process_all_files(self):
-        """Process all unprocessed .txt files in the 1-raw-text directory.
-        Runs up to three files concurrently."""
+        """Process all unprocessed .txt files sequentially."""
         unprocessed_files = self._get_unprocessed_files()
         if not unprocessed_files:
             safe_print(colored("No unprocessed .txt files found in 1-raw-text. Exiting.", 'gray'))
             sys.exit(0)
         safe_print(colored(f"Found {len(unprocessed_files)} files to process", 'yellow'))
 
-        def worker(fname: str):
-            processor = LongChainTextPreprocessor()
-            processor.process_file(fname)
-
-        max_workers = min(3, len(unprocessed_files))
-        stop_event = threading.Event()
-        printer = threading.Thread(target=progress_printer, args=(stop_event,), daemon=True)
-        printer.start()
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = {executor.submit(worker, f): f for f in unprocessed_files}
-            for future in as_completed(futures):
-                fname = futures[future]
-                try:
-                    future.result()
-                except Exception as e:
-                    safe_print(colored(f"Error processing {fname}: {str(e)}", 'red'))
-        stop_event.set()
-        printer.join()
+        for fname in unprocessed_files:
+            try:
+                self.process_file(fname)
+            except Exception as e:
+                safe_print(colored(f"Error processing {fname}: {str(e)}", 'red'))
 
 if __name__ == "__main__":
     try:

--- a/audiobook-tts/src/split_voice_lines.py
+++ b/audiobook-tts/src/split_voice_lines.py
@@ -1,5 +1,6 @@
 import os
 import re
+from text_utils import TextUtils
 import json
 import yaml
 import argparse
@@ -15,8 +16,6 @@ zonos_min_chars = config["models"]["zonos"]["min_characters"]
 zonos_max_chars = config["models"]["zonos"]["max_characters"]
 
 # --- Splitting Functions ---
-
-ABBREVS = {"dr", "mr", "mrs", "ms", "etc"}  # Lowercase set for quick check
 
 def parse_speakers(full_text, default_voice):
     """
@@ -58,132 +57,6 @@ def parse_speakers(full_text, default_voice):
             segments.append((default_voice, final_text, ""))
     return segments
 
-def _split_regular_text(text):
-    sentences = []
-    buffer = []
-    i = 0
-    n = len(text)
-    while i < n:
-        ch = text[i]
-        buffer.append(ch)
-        if ch in {'.', '!', '?'}:
-            next_char = text[i + 1] if (i + 1 < n) else ''
-            if next_char.isspace() or i == n - 1:
-                temp_str = "".join(buffer)
-                match = re.search(r"\b([A-Za-z]+)\.$", temp_str)
-                if match:
-                    word_before_dot = match.group(1).lower()
-                    if word_before_dot in ABBREVS:
-                        pass
-                    else:
-                        sentences.append(temp_str.strip())
-                        buffer = []
-                        while i + 1 < n and text[i + 1].isspace():
-                            i += 1
-                else:
-                    sentences.append(temp_str.strip())
-                    buffer = []
-                    while i + 1 < n and text[i + 1].isspace():
-                        i += 1
-        i += 1
-    leftover = "".join(buffer).strip()
-    if leftover:
-        sentences.append(leftover)
-    return sentences
-
-def initial_split_into_sentences(text):
-    text = re.sub(r'\s*</pause>', '', text)
-    parts = re.split(r'(<pause\s+duration="(?:short|long)"\s*/?>)', text)
-    sentences = []
-    for i, part in enumerate(parts):
-        if i % 2 == 0:
-            sub_sentences = _split_regular_text(part)
-            if sub_sentences:
-                sentences.extend(sub_sentences)
-        else:
-            m = re.search(r'duration="(short|long)"', part)
-            duration = m.group(1) if m else "short"
-            if sentences:
-                sentences[-1] = sentences[-1].strip() + " ||PAUSE:" + duration + "||"
-            else:
-                sentences.append("||PAUSE:" + duration + "||")
-    return sentences
-
-def split_on_delims(long_text, max_len):
-    def splitter(text, delimiters):
-        pieces = [text]
-        for delim in delimiters:
-            new_pieces = []
-            for p in pieces:
-                if len(p) <= max_len:
-                    new_pieces.append(p)
-                else:
-                    sub_parts = p.split(delim)
-                    for sp in sub_parts:
-                        sp = sp.strip()
-                        if sp:
-                            new_pieces.append(sp)
-            pieces = new_pieces
-        return pieces
-
-    candidate_delims = [" - ", ", "]
-    splitted = splitter(long_text, candidate_delims)
-    final_list = []
-    for piece in splitted:
-        if len(piece) > max_len:
-            final_list.extend(force_split_long_text(piece, max_chars=max_len))
-        else:
-            final_list.append(piece)
-    return final_list
-
-def force_split_long_text(text, max_chars):
-    if len(text) <= max_chars:
-        return [text]
-
-    splits = []
-    start = 0
-    length = len(text)
-    while start < length:
-        end = start + max_chars
-        if end >= length:
-            splits.append(text[start:].strip())
-            break
-        space_index = text.rfind(" ", start, end)
-        if space_index == -1 or space_index < start:
-            splits.append(text[start:end].strip())
-            start = end
-        else:
-            splits.append(text[start:space_index].strip())
-            start = space_index + 1
-    return splits
-
-def combine_into_blocks(sentences, min_chars, max_chars):
-    blocks = []
-    current = ""
-    for sentence in sentences:
-        m = re.search(r'\|\|PAUSE:(short|long)\|\|$', sentence)
-        if m:
-            pause = m.group(1)
-            sentence_text = sentence[:sentence.rfind("||PAUSE:")].strip()
-            if current:
-                blocks.append((current.strip(), ""))
-                current = ""
-            blocks.append((sentence_text, pause))
-        else:
-            if not current:
-                current = sentence
-            else:
-                if len(current) + 1 + len(sentence) <= max_chars:
-                    current += " " + sentence
-                else:
-                    if len(current) >= min_chars:
-                        blocks.append((current.strip(), ""))
-                        current = sentence
-                    else:
-                        current += " " + sentence
-    if current.strip():
-        blocks.append((current.strip(), ""))
-    return blocks
 
 # --- Main function: split_voice_lines ---
 
@@ -233,15 +106,15 @@ def split_voice_lines(input_file=None, input_dir="2-annotated-text", temp_folder
             model_min_chars = zonos_min_chars if model == "zonos" else kokoro_min_chars
             model_max_chars = zonos_max_chars if model == "zonos" else kokoro_max_chars
 
-            sentences = initial_split_into_sentences(segment_text)
+            sentences = TextUtils.initial_split_into_sentences(segment_text)
             refined = []
             for s in sentences:
                 if len(s) > model_max_chars:
-                    refined.extend(split_on_delims(s, max_len=model_max_chars))
+                    refined.extend(TextUtils.split_on_delims(s, max_len=model_max_chars))
                 else:
                     refined.append(s)
 
-            blocks = combine_into_blocks(refined, min_chars=model_min_chars, max_chars=model_max_chars)
+            blocks = TextUtils.combine_into_blocks(refined, min_chars=model_min_chars, max_chars=model_max_chars)
             for block_text, pause in blocks:
                 block_text = block_text.strip()
                 if block_text:

--- a/audiobook-tts/src/text_utils.py
+++ b/audiobook-tts/src/text_utils.py
@@ -1,0 +1,158 @@
+class TextUtils:
+    ABBREVS = {"dr", "mr", "mrs", "ms", "etc"}
+
+    @staticmethod
+    def _split_regular_text(text: str):
+        sentences = []
+        buffer = []
+        i = 0
+        n = len(text)
+        while i < n:
+            ch = text[i]
+            buffer.append(ch)
+            if ch in {'.', '!', '?'}:
+                next_char = text[i + 1] if (i + 1 < n) else ''
+                if next_char.isspace() or i == n - 1:
+                    temp_str = "".join(buffer)
+                    import re
+                    match = re.search(r"\b([A-Za-z]+)\.$", temp_str)
+                    if match:
+                        word_before_dot = match.group(1).lower()
+                        if word_before_dot in TextUtils.ABBREVS:
+                            pass
+                        else:
+                            sentences.append(temp_str.strip())
+                            buffer = []
+                            while i + 1 < n and text[i + 1].isspace():
+                                i += 1
+                    else:
+                        sentences.append(temp_str.strip())
+                        buffer = []
+                        while i + 1 < n and text[i + 1].isspace():
+                            i += 1
+            i += 1
+        leftover = "".join(buffer).strip()
+        if leftover:
+            sentences.append(leftover)
+        return sentences
+
+    @staticmethod
+    def initial_split_into_sentences(text: str):
+        import re
+        text = re.sub(r'\s*</pause>', '', text)
+        parts = re.split(r'(<pause\s+duration="(?:short|long)"\s*/?>)', text)
+        sentences = []
+        for i, part in enumerate(parts):
+            if i % 2 == 0:
+                sub_sentences = TextUtils._split_regular_text(part)
+                if sub_sentences:
+                    sentences.extend(sub_sentences)
+            else:
+                m = re.search(r'duration="(short|long)"', part)
+                duration = m.group(1) if m else "short"
+                if sentences:
+                    sentences[-1] = sentences[-1].strip() + " ||PAUSE:" + duration + "||"
+                else:
+                    sentences.append("||PAUSE:" + duration + "||")
+        return sentences
+
+    @staticmethod
+    def force_split_long_text(text: str, max_chars: int):
+        if len(text) <= max_chars:
+            return [text]
+        splits = []
+        start = 0
+        length = len(text)
+        while start < length:
+            end = start + max_chars
+            if end >= length:
+                splits.append(text[start:].strip())
+                break
+            space_index = text.rfind(" ", start, end)
+            if space_index == -1 or space_index < start:
+                splits.append(text[start:end].strip())
+                start = end
+            else:
+                splits.append(text[start:space_index].strip())
+                start = space_index + 1
+        return splits
+
+    @staticmethod
+    def split_on_delims(long_text: str, max_len: int):
+        def splitter(text, delimiters):
+            pieces = [text]
+            for delim in delimiters:
+                new_pieces = []
+                for p in pieces:
+                    if len(p) <= max_len:
+                        new_pieces.append(p)
+                    else:
+                        sub_parts = p.split(delim)
+                        for sp in sub_parts:
+                            sp = sp.strip()
+                            if sp:
+                                new_pieces.append(sp)
+                pieces = new_pieces
+            return pieces
+        candidate_delims = [" - ", ", "]
+        splitted = splitter(long_text, candidate_delims)
+        final_list = []
+        for piece in splitted:
+            if len(piece) > max_len:
+                final_list.extend(TextUtils.force_split_long_text(piece, max_chars=max_len))
+            else:
+                final_list.append(piece)
+        return final_list
+
+    @staticmethod
+    def combine_into_blocks(sentences, min_chars: int, max_chars: int):
+        import re
+        blocks = []
+        current = ""
+        for sentence in sentences:
+            m = re.search(r'\|\|PAUSE:(short|long)\|\|$', sentence)
+            if m:
+                pause = m.group(1)
+                sentence_text = sentence[:sentence.rfind("||PAUSE:")].strip()
+                if current:
+                    blocks.append((current.strip(), ""))
+                    current = ""
+                blocks.append((sentence_text, pause))
+            else:
+                if not current:
+                    current = sentence
+                else:
+                    if len(current) + 1 + len(sentence) <= max_chars:
+                        current += " " + sentence
+                    else:
+                        if len(current) >= min_chars:
+                            blocks.append((current.strip(), ""))
+                            current = sentence
+                        else:
+                            current += " " + sentence
+        if current.strip():
+            blocks.append((current.strip(), ""))
+        return blocks
+
+    @staticmethod
+    def chunk_text(text: str, max_chars: int = 10000):
+        sentences = TextUtils.initial_split_into_sentences(text)
+        chunks = []
+        current = ""
+        for sentence in sentences:
+            if len(current) + 1 + len(sentence) <= max_chars:
+                if current:
+                    current += " " + sentence
+                else:
+                    current = sentence
+            else:
+                if current:
+                    chunks.append(current.strip())
+                if len(sentence) > max_chars:
+                    chunks.extend(TextUtils.force_split_long_text(sentence, max_chars=max_chars))
+                    current = ""
+                else:
+                    current = sentence
+        if current.strip():
+            chunks.append(current.strip())
+        return chunks


### PR DESCRIPTION
## Summary
- add new prompt to extract all speakers
- include character summary in editing prompt
- introduce shared `TextUtils` utilities for splitting text
- update `split_voice_lines` to use new utilities
- refactor `lang_chain_text_preprocessor` to determine speakers first and process text chunks concurrently

## Testing
- `python -m py_compile audiobook-tts/src/*.py`

------
https://chatgpt.com/codex/tasks/task_b_687bdbeabee4832a89421097da5c1746